### PR TITLE
Make wget installation optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,11 @@ class kafka (
     }
   }
 
-  ensure_resource('package','wget', { 'ensure' => 'present' })
+  if ! defined(Package['wget']) {
+    package {'wget':
+      ensure => present
+    }
+  }
 
   group { 'kafka':
     ensure => present


### PR DESCRIPTION
Add an install_wget parameter to allow users to entirely disable management of wget. The require on an exec will still expect the resource to be exist, so it must be provided via another module if install_wget is set to false.