### PR TITLE
Runuser doesn't exist in Ubuntu12.*/14.*, using su instead

### DIFF
--- a/templates/init.erb
+++ b/templates/init.erb
@@ -32,7 +32,7 @@ start() {
       start
     fi
   else
-    /sbin/runuser $KAFKA_USER -c "KAFKA_JMX_OPTS=\"$KAFKA_JMX_OPTS\" $DAEMON $DAEMON_OPTS > /var/log/kafka/server.out 2> /var/log/kafka/server.err &"
+    /bin/su $KAFKA_USER -c "KAFKA_JMX_OPTS=\"$KAFKA_JMX_OPTS\" $DAEMON $DAEMON_OPTS > /var/log/kafka/server.out 2> /var/log/kafka/server.err &"
     sleep 2
     PID=`ps ax | grep -E '[k]afka.Kafka' | awk '{print $1}'`
     echo $PID > $PID_FILE;


### PR DESCRIPTION
Runuser comes with version 2.23 of util-linux which doesn't exist
in ubuntu12.* or 14.* repositories so a backport or custom compilation is needed

I don't think is worth breaking the Ubuntu compatibility of this
puppet module just because of this, so using "su" instead of runuser
is more appropiate